### PR TITLE
Fix flashcard navigation path

### DIFF
--- a/vokaloka/src/pages/DashboardPage.tsx
+++ b/vokaloka/src/pages/DashboardPage.tsx
@@ -31,7 +31,7 @@ export default function DashboardPage() {
         <section style={styles.nextReview}>
           <h2>🗂️ Next Review Session</h2>
           <p>Stay sharp — consistency fuels fluency!</p>
-          <button style={styles.button} onClick={() => navigate('/FlashcardPage')}>
+          <button style={styles.button} onClick={() => navigate('/review')}>
             Start Reviewing
           </button>
         </section>


### PR DESCRIPTION
## Summary
- correct `DashboardPage` navigation to use `/review`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b55c7a5e08327b25c91a0a98f4f1a